### PR TITLE
Update Charms to allow repairs on standard anvil.

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/data/IHasRecipeAndRepair.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/data/IHasRecipeAndRepair.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * The MIT License (MIT)
+ * 
+ * Copyright (C) 2014-2018 Sam Bassett (aka Lothrazar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+package com.lothrazar.cyclicmagic.data;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+
+public interface IHasRecipeAndRepair {
+
+  IRecipe addRecipeAndRepair();
+  boolean getIsRepairable(ItemStack par1ItemStack, ItemStack par2ItemStack);
+}

--- a/src/main/java/com/lothrazar/cyclicmagic/item/core/BaseCharm.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/core/BaseCharm.java
@@ -80,10 +80,6 @@ public abstract class BaseCharm extends BaseItem implements IHasClickToggle, bau
     UtilItemStack.damageItem(living, stack);
   }
 
-  public IRecipe addRecipeAndRepair(Item craftItem) {
-    return this.addRecipe(new ItemStack(craftItem));
-  }
-
   /**
    * Called each tick as long the item is on a player inventory. Uses by maps to check if is on a player hand and update it's contents.
    */

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmAir.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmAir.java
@@ -25,7 +25,7 @@ package com.lothrazar.cyclicmagic.item.equipbauble;
 
 import com.lothrazar.cyclicmagic.IContent;
 import com.lothrazar.cyclicmagic.ModCyclic;
-import com.lothrazar.cyclicmagic.data.IHasRecipe;
+import com.lothrazar.cyclicmagic.data.IHasRecipeAndRepair;
 import com.lothrazar.cyclicmagic.guide.GuideCategory;
 import com.lothrazar.cyclicmagic.item.core.BaseCharm;
 import com.lothrazar.cyclicmagic.net.PacketPlayerFalldamage;
@@ -41,11 +41,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.config.Configuration;
 
-public class ItemCharmAir extends BaseCharm implements IHasRecipe, IContent {
+public class ItemCharmAir extends BaseCharm implements IHasRecipeAndRepair, IContent {
 
   private static final double DOWNWARD_SPEED_SNEAKING = -0.32;
   private static final int TICKS_FALLDIST_SYNC = 22;//tick every so often
   private static final int durability = 4096;
+  private static final ItemStack craftItem = new ItemStack(Blocks.BONE_BLOCK);
 
   public ItemCharmAir() {
     super(durability);
@@ -96,7 +97,13 @@ public class ItemCharmAir extends BaseCharm implements IHasRecipe, IContent {
   }
 
   @Override
-  public IRecipe addRecipe() {
-    return super.addRecipe(new ItemStack(Blocks.BONE_BLOCK));
+  public boolean getIsRepairable(ItemStack par1ItemStack, ItemStack par2ItemStack)
+  {
+    return par2ItemStack.getItem() == craftItem.getItem();
+  }
+
+  @Override
+  public IRecipe addRecipeAndRepair() {
+    return super.addRecipe(craftItem);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmAntidote.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmAntidote.java
@@ -24,7 +24,7 @@
 package com.lothrazar.cyclicmagic.item.equipbauble;
 
 import com.lothrazar.cyclicmagic.IContent;
-import com.lothrazar.cyclicmagic.data.IHasRecipe;
+import com.lothrazar.cyclicmagic.data.IHasRecipeAndRepair;
 import com.lothrazar.cyclicmagic.guide.GuideCategory;
 import com.lothrazar.cyclicmagic.item.core.BaseCharm;
 import com.lothrazar.cyclicmagic.registry.ItemRegistry;
@@ -37,9 +37,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraftforge.common.config.Configuration;
 
-public class ItemCharmAntidote extends BaseCharm implements IHasRecipe, IContent {
+public class ItemCharmAntidote extends BaseCharm implements IHasRecipeAndRepair, IContent {
 
   private static final int durability = 32;
+  private static final ItemStack craftItem = new ItemStack(Items.FERMENTED_SPIDER_EYE);
 
   public ItemCharmAntidote() {
     super(durability);
@@ -79,7 +80,13 @@ public class ItemCharmAntidote extends BaseCharm implements IHasRecipe, IContent
   }
 
   @Override
-  public IRecipe addRecipe() {
-    return super.addRecipeAndRepair(Items.FERMENTED_SPIDER_EYE);
+  public boolean getIsRepairable(ItemStack par1ItemStack, ItemStack par2ItemStack)
+  {
+    return par2ItemStack.getItem() == craftItem.getItem();
+  }
+
+  @Override
+  public IRecipe addRecipeAndRepair() {
+    return super.addRecipe(craftItem);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmBoat.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmBoat.java
@@ -24,7 +24,7 @@
 package com.lothrazar.cyclicmagic.item.equipbauble;
 
 import com.lothrazar.cyclicmagic.IContent;
-import com.lothrazar.cyclicmagic.data.IHasRecipe;
+import com.lothrazar.cyclicmagic.data.IHasRecipeAndRepair;
 import com.lothrazar.cyclicmagic.guide.GuideCategory;
 import com.lothrazar.cyclicmagic.item.core.BaseCharm;
 import com.lothrazar.cyclicmagic.registry.ItemRegistry;
@@ -38,9 +38,10 @@ import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 import net.minecraftforge.common.config.Configuration;
 
-public class ItemCharmBoat extends BaseCharm implements IHasRecipe, IContent {
+public class ItemCharmBoat extends BaseCharm implements IHasRecipeAndRepair, IContent {
 
   private static final int durability = 4096;
+  private static final ItemStack craftItem = new ItemStack(Items.ARMOR_STAND);
 
   public ItemCharmBoat() {
     super(durability);
@@ -93,7 +94,13 @@ public class ItemCharmBoat extends BaseCharm implements IHasRecipe, IContent {
   }
 
   @Override
-  public IRecipe addRecipe() {
-    return super.addRecipeAndRepair(Items.ARMOR_STAND);
+  public boolean getIsRepairable(ItemStack par1ItemStack, ItemStack par2ItemStack)
+  {
+    return par2ItemStack.getItem() == craftItem.getItem();
+  }
+
+  @Override
+  public IRecipe addRecipeAndRepair() {
+    return super.addRecipe(craftItem);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmFire.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmFire.java
@@ -24,7 +24,7 @@
 package com.lothrazar.cyclicmagic.item.equipbauble;
 
 import com.lothrazar.cyclicmagic.IContent;
-import com.lothrazar.cyclicmagic.data.IHasRecipe;
+import com.lothrazar.cyclicmagic.data.IHasRecipeAndRepair;
 import com.lothrazar.cyclicmagic.guide.GuideCategory;
 import com.lothrazar.cyclicmagic.item.core.BaseCharm;
 import com.lothrazar.cyclicmagic.registry.ItemRegistry;
@@ -43,10 +43,11 @@ import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.world.World;
 import net.minecraftforge.common.config.Configuration;
 
-public class ItemCharmFire extends BaseCharm implements IHasRecipe, IContent {
+public class ItemCharmFire extends BaseCharm implements IHasRecipeAndRepair, IContent {
 
   private static final int durability = 16;
   private static final int seconds = 10;
+  private static final ItemStack craftItem = new ItemStack(Items.BLAZE_ROD);
 
   public ItemCharmFire() {
     super(durability);
@@ -86,7 +87,13 @@ public class ItemCharmFire extends BaseCharm implements IHasRecipe, IContent {
   }
 
   @Override
-  public IRecipe addRecipe() {
-    return super.addRecipeAndRepair(Items.BLAZE_ROD);
+  public boolean getIsRepairable(ItemStack par1ItemStack, ItemStack par2ItemStack)
+  {
+    return par2ItemStack.getItem() == craftItem.getItem();
+  }
+
+  @Override
+  public IRecipe addRecipeAndRepair() {
+    return super.addRecipe(craftItem);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmSlowfall.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmSlowfall.java
@@ -24,7 +24,7 @@
 package com.lothrazar.cyclicmagic.item.equipbauble;
 
 import com.lothrazar.cyclicmagic.IContent;
-import com.lothrazar.cyclicmagic.data.IHasRecipe;
+import com.lothrazar.cyclicmagic.data.IHasRecipeAndRepair;
 import com.lothrazar.cyclicmagic.guide.GuideCategory;
 import com.lothrazar.cyclicmagic.item.core.BaseCharm;
 import com.lothrazar.cyclicmagic.potion.PotionEffectRegistry;
@@ -43,12 +43,13 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraftforge.common.config.Configuration;
 
-public class ItemCharmSlowfall extends BaseCharm implements IHasRecipe, IContent {
+public class ItemCharmSlowfall extends BaseCharm implements IHasRecipeAndRepair, IContent {
 
   private final static int seconds = 30;
   private final static int fallDistanceLimit = 6;
   private final static int durability = 64;
   private final static Potion potion = PotionEffectRegistry.SLOWFALL;
+  private static final ItemStack craftItem = new ItemStack(Items.RABBIT_FOOT);
 
   public ItemCharmSlowfall() {
     super(durability);
@@ -91,7 +92,13 @@ public class ItemCharmSlowfall extends BaseCharm implements IHasRecipe, IContent
   }
 
   @Override
-  public IRecipe addRecipe() {
-    return super.addRecipeAndRepair(Items.RABBIT_FOOT);
+  public boolean getIsRepairable(ItemStack par1ItemStack, ItemStack par2ItemStack)
+  {
+    return par2ItemStack.getItem() == craftItem.getItem();
+  }
+
+  @Override
+  public IRecipe addRecipeAndRepair() {
+    return super.addRecipe(craftItem);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmSpeed.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmSpeed.java
@@ -24,7 +24,7 @@
 package com.lothrazar.cyclicmagic.item.equipbauble;
 
 import com.lothrazar.cyclicmagic.IContent;
-import com.lothrazar.cyclicmagic.data.IHasRecipe;
+import com.lothrazar.cyclicmagic.data.IHasRecipeAndRepair;
 import com.lothrazar.cyclicmagic.guide.GuideCategory;
 import com.lothrazar.cyclicmagic.item.core.BaseCharm;
 import com.lothrazar.cyclicmagic.registry.ItemRegistry;
@@ -36,11 +36,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraftforge.common.config.Configuration;
 
-public class ItemCharmSpeed extends BaseCharm implements IHasRecipe, IContent {
+public class ItemCharmSpeed extends BaseCharm implements IHasRecipeAndRepair, IContent {
 
   private static final double CHANCE_DAMAGE = 0.005;
   private static final int durability = 20000;
   private static final float speedfactor = 0.08F;
+  private static final ItemStack craftItem = new ItemStack(Items.EMERALD);
 
   public ItemCharmSpeed() {
     super(durability);
@@ -75,7 +76,13 @@ public class ItemCharmSpeed extends BaseCharm implements IHasRecipe, IContent {
   }
 
   @Override
-  public IRecipe addRecipe() {
-    return super.addRecipe(new ItemStack(Items.EMERALD));
+  public boolean getIsRepairable(ItemStack par1ItemStack, ItemStack par2ItemStack)
+  {
+    return par2ItemStack.getItem() == craftItem.getItem();
+  }
+
+  @Override
+  public IRecipe addRecipeAndRepair() {
+    return this.addRecipe(craftItem);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmVoid.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmVoid.java
@@ -24,7 +24,7 @@
 package com.lothrazar.cyclicmagic.item.equipbauble;
 
 import com.lothrazar.cyclicmagic.IContent;
-import com.lothrazar.cyclicmagic.data.IHasRecipe;
+import com.lothrazar.cyclicmagic.data.IHasRecipeAndRepair;
 import com.lothrazar.cyclicmagic.guide.GuideCategory;
 import com.lothrazar.cyclicmagic.item.core.BaseCharm;
 import com.lothrazar.cyclicmagic.registry.ItemRegistry;
@@ -43,11 +43,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.config.Configuration;
 
-public class ItemCharmVoid extends BaseCharm implements IHasRecipe, IContent {
+public class ItemCharmVoid extends BaseCharm implements IHasRecipeAndRepair, IContent {
 
   private static final int durability = 16;
   private static final int yLowest = -30;
   private static final int yDest = 255;
+  private static final ItemStack craftItem = new ItemStack(Items.ENDER_EYE);
 
   public ItemCharmVoid() {
     super(durability);
@@ -72,11 +73,6 @@ public class ItemCharmVoid extends BaseCharm implements IHasRecipe, IContent {
   }
 
   @Override
-  public IRecipe addRecipe() {
-    return super.addRecipeAndRepair(Items.ENDER_EYE);
-  }
-
-  @Override
   public void onTick(ItemStack stack, EntityPlayer living) {
     if (!this.canTick(stack)) {
       return;
@@ -88,5 +84,16 @@ public class ItemCharmVoid extends BaseCharm implements IHasRecipe, IContent {
       UtilSound.playSound(living, living.getPosition(), SoundEvents.ENTITY_ENDERMEN_TELEPORT, living.getSoundCategory());
       UtilParticle.spawnParticle(worldIn, EnumParticleTypes.PORTAL, living.getPosition());
     }
+  }
+
+  @Override
+  public boolean getIsRepairable(ItemStack par1ItemStack, ItemStack par2ItemStack)
+  {
+    return par2ItemStack.getItem() == craftItem.getItem();
+  }
+
+  @Override
+  public IRecipe addRecipeAndRepair() {
+    return super.addRecipe(craftItem);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmWater.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemCharmWater.java
@@ -24,7 +24,7 @@
 package com.lothrazar.cyclicmagic.item.equipbauble;
 
 import com.lothrazar.cyclicmagic.IContent;
-import com.lothrazar.cyclicmagic.data.IHasRecipe;
+import com.lothrazar.cyclicmagic.data.IHasRecipeAndRepair;
 import com.lothrazar.cyclicmagic.guide.GuideCategory;
 import com.lothrazar.cyclicmagic.item.core.BaseCharm;
 import com.lothrazar.cyclicmagic.registry.ItemRegistry;
@@ -43,11 +43,12 @@ import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.world.World;
 import net.minecraftforge.common.config.Configuration;
 
-public class ItemCharmWater extends BaseCharm implements IHasRecipe, IContent {
+public class ItemCharmWater extends BaseCharm implements IHasRecipeAndRepair, IContent {
 
   private static final int breath = 6;
   private static final int durability = 32;
   private static final int seconds = 60;
+  private static final ItemStack craftItem = new ItemStack(Items.FISH, 1, ItemFishFood.FishType.SALMON.getMetadata());
 
   public ItemCharmWater() {
     super(durability);
@@ -71,11 +72,6 @@ public class ItemCharmWater extends BaseCharm implements IHasRecipe, IContent {
   }
 
   @Override
-  public IRecipe addRecipe() {
-    return super.addRecipe(new ItemStack(Items.FISH, 1, ItemFishFood.FishType.SALMON.getMetadata()));
-  }
-
-  @Override
   public void onTick(ItemStack stack, EntityPlayer living) {
     if (!this.canTick(stack)) {
       return;
@@ -88,5 +84,16 @@ public class ItemCharmWater extends BaseCharm implements IHasRecipe, IContent {
       UtilParticle.spawnParticle(worldIn, EnumParticleTypes.WATER_BUBBLE, living.getPosition());
       UtilParticle.spawnParticle(worldIn, EnumParticleTypes.WATER_BUBBLE, living.getPosition().up());
     }
+  }
+
+  @Override
+  public boolean getIsRepairable(ItemStack par1ItemStack, ItemStack par2ItemStack)
+  {
+    return par2ItemStack.getItem() == craftItem.getItem();
+  }
+
+  @Override
+  public IRecipe addRecipeAndRepair() {
+    return super.addRecipe(craftItem);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/registry/ItemRegistry.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/registry/ItemRegistry.java
@@ -32,6 +32,7 @@ import com.lothrazar.cyclicmagic.block.ore.BlockDimensionOre;
 import com.lothrazar.cyclicmagic.config.IHasConfig;
 import com.lothrazar.cyclicmagic.data.IHasOreDict;
 import com.lothrazar.cyclicmagic.data.IHasRecipe;
+import com.lothrazar.cyclicmagic.data.IHasRecipeAndRepair;
 import com.lothrazar.cyclicmagic.guide.GuideCategory;
 import com.lothrazar.cyclicmagic.guide.GuideRegistry;
 import com.lothrazar.cyclicmagic.item.cannon.EntityGolemLaser;
@@ -75,6 +76,9 @@ public class ItemRegistry {
     IRecipe recipe = null;
     if (item instanceof IHasRecipe) {
       recipe = ((IHasRecipe) item).addRecipe();
+    }
+    else if (item instanceof IHasRecipeAndRepair) {
+      recipe = ((IHasRecipeAndRepair) item).addRecipeAndRepair();
     }
     if (cat != null) {
       GuideRegistry.register(cat, item, recipe, null);


### PR DESCRIPTION
Update Charms to allow repairs on standard anvil with their crafting item (Blaze Rod for Fire Charm, Emerald for Speed Charm, etc).

Addresses Issue #956