### PR TITLE
Fixes to Ender library getting stuck.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ guideapi_version=1.12-2.1.3-55
 crt_version=1.12-4.1.9.478
 fb_version=1.5.3
 ench_descr_version=1.19
-jei_version=4.12.1.217
+jei_version=4.15.0.268
 # jar signing https://tutorials.darkhax.net/tutorials/jar_signing/

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ guideapi_version=1.12-2.1.3-55
 crt_version=1.12-4.1.9.478
 fb_version=1.5.3
 ench_descr_version=1.19
-jei_version=4.15.0.268
+jei_version=4.12.1.217
 # jar signing https://tutorials.darkhax.net/tutorials/jar_signing/

--- a/src/main/java/com/lothrazar/cyclicmagic/block/enchantlibrary/ctrl/BlockLibraryController.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/enchantlibrary/ctrl/BlockLibraryController.java
@@ -99,7 +99,7 @@ public class BlockLibraryController extends BlockBaseHasTile implements IHasReci
       te = world.getTileEntity(p);
       if (te instanceof TileEntityLibrary) {
         lib = (TileEntityLibrary) te;
-        QuadrantEnum quad = lib.findMatchingQuadrant(playerHeld);
+        QuadrantEnum quad = lib.findMatchingQuadrant(playerHeld, lib);
         if (quad != null) {
           target.library = lib;
           target.quad = quad;
@@ -113,7 +113,7 @@ public class BlockLibraryController extends BlockBaseHasTile implements IHasReci
         te = world.getTileEntity(p);
         if (te instanceof TileEntityLibrary) {
           lib = (TileEntityLibrary) te;
-          QuadrantEnum quad = lib.findMatchingQuadrant(playerHeld);
+          QuadrantEnum quad = lib.findMatchingQuadrant(playerHeld, lib);
           if (quad == null) {
             quad = lib.findEmptyQuadrant();
           }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/enchantlibrary/ctrl/TileEntityLibraryCtrl.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/enchantlibrary/ctrl/TileEntityLibraryCtrl.java
@@ -23,6 +23,7 @@
  ******************************************************************************/
 package com.lothrazar.cyclicmagic.block.enchantlibrary.ctrl;
 
+import com.lothrazar.cyclicmagic.ModCyclic;
 import com.lothrazar.cyclicmagic.block.core.TileEntityBaseMachineInvo;
 import com.lothrazar.cyclicmagic.block.enchantlibrary.EnchantStorageTarget;
 import com.lothrazar.cyclicmagic.util.UtilSound;
@@ -61,22 +62,22 @@ public class TileEntityLibraryCtrl extends TileEntityBaseMachineInvo implements 
     if (stackIn.isEmpty()) {
       return;
     }
-    //is it an enchanted book 
+    //is it an enchanted book?
     if (stackIn.getItem().equals(Items.ENCHANTED_BOOK) == false) {
-      //move it to output i dont want it yuky 
+      //move it to output i don't want it yucky
       this.setInventorySlotContents(SLOT_OUT, stackIn);
       this.setInventorySlotContents(SLOT_IN, ItemStack.EMPTY);
       return;
     }
-    //try to apply its action to nearby book hey
+    //try to apply its action to nearby book
     EnchantStorageTarget target = BlockLibraryController.findMatchingTarget(world, pos, stackIn);
-    if (target.isEmpty() == false) {
-      //ModCyclic.logger.error(target.library.getPos() + " ? " + target.quad);
+    if (!target.isEmpty()) {
+      //ModCyclic.logger.error("Target Available @ " + target.library.getPos() + " " + target.quad);
       ItemStack theThing = target.library.addEnchantmentToQuadrant(stackIn, target.quad);
       IBlockState oldState = world.getBlockState(target.library.getPos());
       world.notifyBlockUpdate(target.library.getPos(), oldState, oldState, 3);
       this.setInventorySlotContents(SLOT_IN, ItemStack.EMPTY);
-      if (theThing.isEmpty() == false) {
+      if (!theThing.isEmpty()) {
         UtilSound.playSound(world, pos, SoundEvents.BLOCK_ENCHANTMENT_TABLE_USE, SoundCategory.BLOCKS);
         //its not empty, but what is it 
         if (theThing.getItem().equals(Items.ENCHANTED_BOOK)) {
@@ -90,6 +91,11 @@ public class TileEntityLibraryCtrl extends TileEntityBaseMachineInvo implements 
       else {
         this.setInventorySlotContents(SLOT_OUT, new ItemStack(Items.BOOK));
       }
+    }
+    else {
+      //ModCyclic.logger.error("No target available, book out");
+      this.setInventorySlotContents(SLOT_OUT, stackIn);
+      this.setInventorySlotContents(SLOT_IN, ItemStack.EMPTY);
     }
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/block/enchantlibrary/shelf/TileEntityLibrary.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/enchantlibrary/shelf/TileEntityLibrary.java
@@ -181,10 +181,13 @@ public class TileEntityLibrary extends TileEntityBaseMachine implements ITickabl
     return null;
   }
 
-  public QuadrantEnum findMatchingQuadrant(ItemStack enchBookStack) {
+  public QuadrantEnum findMatchingQuadrant(ItemStack enchBookStack, TileEntityLibrary lib) {
     for (int i = 0; i < storage.length; i++) {
       if (storage[i].doesMatchNonEmpty(enchBookStack)) {
-        return QuadrantEnum.values()[i];
+        QuadrantEnum quad = QuadrantEnum.values()[i];
+        if (lib.getEnchantStack(quad).getCount() < TileEntityLibrary.MAX_COUNT) {
+          return quad;
+        }
       }
     }
     return null;


### PR DESCRIPTION
 Books with no target no longer get stuck, sent to output slot instead. Fixes #1154

* Books now overflow to a second drawer if first is full. Fixes #1154

* Books with multiple enchantments where the first found enchantment has no target location are correctly handled.

* Changes allow multiple ender libraries to work in series