### PR TITLE
Rework Max Health into Max Health Modifier

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/capability/IPlayerExtendedProperties.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/capability/IPlayerExtendedProperties.java
@@ -17,9 +17,9 @@ public interface IPlayerExtendedProperties {
 
   void setInventoryExtended(boolean value);
 
-  int getMaxHealth();
+  int getMaxHealthModifier();
 
-  void setMaxHealth(int value);
+  void setMaxHealthModifier(int value);
 
   NBTTagCompound getDataAsNBT();
 

--- a/src/main/java/com/lothrazar/cyclicmagic/capability/InstancePlayerExtendedProperties.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/capability/InstancePlayerExtendedProperties.java
@@ -9,7 +9,8 @@ import net.minecraft.util.math.BlockPos;
 
 public class InstancePlayerExtendedProperties implements IPlayerExtendedProperties {
 
-  private static final String MHEALTH = "mhealth";
+  private static final String OLD_MHEALTH = "mhealth";
+  private static final String MOD_HEALTH = "modhealth";
   private static final String NBT_TODO = "todo";
   private static final String HAS_INVENTORY_EXTENDED = "hasInventoryExtended";
   private static final String HAS_INVENTORY_CRAFTING = "hasInventoryCrafting";
@@ -27,7 +28,7 @@ public class InstancePlayerExtendedProperties implements IPlayerExtendedProperti
   private boolean hasInventoryCrafting = false;
   private boolean hasInventoryExtended = false;
   private String todo = "";
-  private int health = ItemHeartContainer.defaultHearts * 2;//two health per heart. magic number alert!
+  private int healthModifier = ItemHeartContainer.heartModifierInitial * 2;//two health per heart. magic number alert!
   private boolean isChorusSpectator = false;
   private BlockPos chorusStart = null;
   private int chorusDim = 0;
@@ -71,7 +72,7 @@ public class InstancePlayerExtendedProperties implements IPlayerExtendedProperti
     tags.setByte(HAS_INVENTORY_CRAFTING, (byte) (this.hasInventoryCrafting() ? 1 : 0));
     tags.setByte(HAS_INVENTORY_EXTENDED, (byte) (this.hasInventoryExtended() ? 1 : 0));
     tags.setString(NBT_TODO, this.getTODO());
-    tags.setInteger(MHEALTH, this.getMaxHealth());
+    tags.setInteger(MOD_HEALTH, this.getMaxHealthModifier());
     tags.setBoolean(KEY_BOOLEAN, this.isChorusSpectator);
     tags.setString(KEY_EATLOC, UtilNBT.posToStringCSV(this.chorusStart));
     tags.setInteger(KEY_EATDIM, this.chorusDim);
@@ -96,7 +97,14 @@ public class InstancePlayerExtendedProperties implements IPlayerExtendedProperti
     this.setInventoryCrafting(tags.getByte(HAS_INVENTORY_CRAFTING) == 1);
     this.setInventoryExtended(tags.getByte(HAS_INVENTORY_EXTENDED) == 1);
     this.setTODO(tags.getString(NBT_TODO));
-    this.setMaxHealth(tags.getInteger(MHEALTH));
+    // Migrate from old max health
+    if (tags.hasKey(OLD_MHEALTH)) {
+      int healthModifier = tags.getInteger(OLD_MHEALTH) - 20;
+      this.setMaxHealthModifier(healthModifier);
+      tags.setInteger(MOD_HEALTH, healthModifier);
+      tags.removeTag(OLD_MHEALTH);
+    }
+    this.setMaxHealthModifier(tags.getInteger(MOD_HEALTH));
     this.setChorusDim(tags.getInteger(KEY_EATDIM));
     this.setChorusTimer(tags.getInteger(KEY_TIMER));
     this.setChorusOn(tags.getBoolean(KEY_BOOLEAN));
@@ -121,13 +129,13 @@ public class InstancePlayerExtendedProperties implements IPlayerExtendedProperti
   }
 
   @Override
-  public int getMaxHealth() {
-    return health;
+  public int getMaxHealthModifier() {
+    return healthModifier;
   }
 
   @Override
-  public void setMaxHealth(int value) {
-    health = value;
+  public void setMaxHealthModifier(int value) {
+    healthModifier = value;
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/command/CommandHearts.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/command/CommandHearts.java
@@ -35,7 +35,7 @@ import net.minecraft.server.MinecraftServer;
 
 public class CommandHearts extends BaseCommand implements ICommand {
 
-  public static final String name = "sethearts";
+  public static final String name = "setheartmod";
 
   public CommandHearts(boolean op) {
     super(name, op);
@@ -44,13 +44,13 @@ public class CommandHearts extends BaseCommand implements ICommand {
 
   @Override
   public String getUsage(ICommandSender sender) {
-    return "/" + getName() + " <player> <hearts>";
+    return "/" + getName() + " <player> <heart modifier>";
   }
 
   @Override
   public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
     EntityPlayer ptarget = null;
-    int hearts = 0;
+    int heartModifier = 0;
     try {
       ptarget = super.getPlayerByUsername(server, args[0]);
       if (ptarget == null) {
@@ -63,18 +63,18 @@ public class CommandHearts extends BaseCommand implements ICommand {
       return;
     }
     try {
-      hearts = Integer.parseInt(args[1]);
+      heartModifier = Integer.parseInt(args[1]);
     }
     catch (Exception e) {
       UtilChat.addChatMessage(sender, getUsage(sender));
       return;
     }
-    if (hearts < 1) {
-      hearts = 1;
+    if (heartModifier < -9) {
+      heartModifier = -9;
     }
-    int health = hearts * 2;
+    int healthModifier = heartModifier * 2;
     IPlayerExtendedProperties prop = CapabilityRegistry.getPlayerProperties(ptarget);
-    prop.setMaxHealth(health);
-    UtilEntity.setMaxHealth(ptarget, health);
+    prop.setMaxHealthModifier(healthModifier);
+    UtilEntity.setMaxHealthModifier(ptarget, healthModifier);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/event/EventPlayerData.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/event/EventPlayerData.java
@@ -52,7 +52,7 @@ public class EventPlayerData {
       EntityPlayerMP p = (EntityPlayerMP) event.player;
       if (p != null) {
         CapabilityRegistry.syncServerDataToClient(p);
-        setDefaultHealth(p);
+        setHealthModifier(p);
       }
     }
   }
@@ -66,16 +66,16 @@ public class EventPlayerData {
       EntityPlayerMP p = (EntityPlayerMP) event.getEntity();
       if (p != null) {
         CapabilityRegistry.syncServerDataToClient(p);
-        setDefaultHealth(p);
+        setHealthModifier(p);
       }
     }
   }
 
-  private void setDefaultHealth(EntityPlayerMP p) {
+  private void setHealthModifier(EntityPlayerMP p) {
     IPlayerExtendedProperties src = CapabilityRegistry.getPlayerProperties(p);
-    //    UtilChat.sendStatusMessage(p,"Setting your maximum health to "+src.getMaxHealth());
-    if (src.getMaxHealth() > 0) {
-      UtilEntity.setMaxHealth(p, src.getMaxHealth());
+    //    UtilChat.sendStatusMessage(p,"Setting your maximum health modifier to "+src.getMaxHealthModifier());
+    if (src.getMaxHealthModifier() != 0) {
+      UtilEntity.setMaxHealthModifier(p, src.getMaxHealthModifier());
     }
   }
 
@@ -101,8 +101,8 @@ public class EventPlayerData {
     IPlayerExtendedProperties src = CapabilityRegistry.getPlayerProperties(event.getOriginal());
     IPlayerExtendedProperties dest = CapabilityRegistry.getPlayerProperties(event.getEntityPlayer());
     dest.setDataFromNBT(src.getDataAsNBT());
-    if (src.getMaxHealth() > 0) {
-      UtilEntity.setMaxHealth(event.getEntityPlayer(), src.getMaxHealth());
+    if (src.getMaxHealthModifier() != 0) {
+      UtilEntity.setMaxHealthModifier(event.getEntityPlayer(), src.getMaxHealthModifier());
     }
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/net/PacketSyncPlayerHealth.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/net/PacketSyncPlayerHealth.java
@@ -36,24 +36,24 @@ import net.minecraftforge.fml.relauncher.Side;
 
 public class PacketSyncPlayerHealth implements IMessage, IMessageHandler<PacketSyncPlayerHealth, IMessage> {
 
-  private int health;
+  private int healthModifier;
 
   public PacketSyncPlayerHealth() {}
 
   public PacketSyncPlayerHealth(int h) {
-    health = h;
+    healthModifier = h;
   }
 
   @Override
   public void fromBytes(ByteBuf buf) {
     NBTTagCompound tags = ByteBufUtils.readTag(buf);
-    health = tags.getInteger("h");
+    healthModifier = tags.getInteger("h");
   }
 
   @Override
   public void toBytes(ByteBuf buf) {
     NBTTagCompound tags = new NBTTagCompound();
-    tags.setInteger("h", health);
+    tags.setInteger("h", healthModifier);
     ByteBufUtils.writeTag(buf, tags);
   }
 
@@ -63,7 +63,7 @@ public class PacketSyncPlayerHealth implements IMessage, IMessageHandler<PacketS
       EntityPlayer p = ModCyclic.proxy.getPlayerEntity(ctx);
       if (p != null) {
         //force clientside hearts to update and match real value
-        UtilEntity.setMaxHealth(p, message.health);
+        UtilEntity.setMaxHealthModifier(p, message.healthModifier);
       }
     }
     return null;

--- a/src/main/java/com/lothrazar/cyclicmagic/proxy/ClientProxy.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/proxy/ClientProxy.java
@@ -237,8 +237,8 @@ public class ClientProxy extends CommonProxy {
       IPlayerExtendedProperties props = CapabilityRegistry.getPlayerProperties(getClientPlayer());
       if (props != null) {
         props.setDataFromNBT(tags);
-        if (props.getMaxHealth() != 0 && props.getMaxHealth() > player.getMaxHealth()) {//it doesnt always need to do this somehow. i get 24>20 sometimes then 24>24 other tiems
-          UtilEntity.setMaxHealth(player, props.getMaxHealth());
+        if (props.getMaxHealthModifier() != 0) {
+          UtilEntity.setMaxHealthModifier(player, props.getMaxHealthModifier());
         }
       }
     }

--- a/src/main/java/com/lothrazar/cyclicmagic/util/UtilEntity.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/util/UtilEntity.java
@@ -105,9 +105,8 @@ public class UtilEntity {
     }
   }
 
-  public static void setMaxHealth(EntityLivingBase living, double max) {
+  public static void setMaxHealthModifier(EntityLivingBase living, double amount) {
     IAttributeInstance healthAttribute = living.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH);
-    double amount = max - healthAttribute.getBaseValue();
     AttributeModifier modifier = healthAttribute.getModifier(HEALTH_MODIFIER_ID);
     // Need to remove modifier to apply a new one
     if (modifier != null) {
@@ -118,20 +117,19 @@ public class UtilEntity {
     healthAttribute.applyModifier(modifier);
   }
 
-  public static double getMaxHealth(EntityLivingBase living) {
+  public static double getMaxHealthModifier(EntityLivingBase living) {
     IAttributeInstance healthAttribute = living.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH);
-    double maxHealth = healthAttribute.getBaseValue();
     AttributeModifier modifier = healthAttribute.getModifier(HEALTH_MODIFIER_ID);
     if (modifier != null) {
-      maxHealth += modifier.getAmount();
+      return modifier.getAmount();
     }
-    return maxHealth;
+    return 0;
   }
 
-  public static int incrementMaxHealth(EntityLivingBase living, int by) {
-    int newVal = (int) getMaxHealth(living) + by;
-    setMaxHealth(living, newVal);
-    return newVal;
+  public static int incrementMaxHealthModifier(EntityLivingBase living, int by) {
+    int newModifier = (int) getMaxHealthModifier(living) + by;
+    setMaxHealthModifier(living, newModifier);
+    return newModifier;
   }
 
   public static EnumFacing getFacing(EntityLivingBase entity) {


### PR DESCRIPTION
## Minecraft version & Mod Version:
Minecraft: 1.12.2
Forge: 14.23.4.2727
Cyclic: 1.12.2-1.19.18 (changes based on https://github.com/Lothrazar/Cyclic/commit/5782e0f79bd4f67d52cb03659b97771a315fc83a)
### Mods used for testing
Scaling Health: 1.12.2-1.3.42+147
MineKraft: Ultra: 0.99.11
### Supporting mods in test profile:
Just Enough Items: 1.12.2-4.15.0.291
Silent Lib: 1.12.2-3.0.13+167
TargetingAPI: 0.15

## Single player or Server:
Both are affected

## Describe problem (what you were doing / what happened):
Cyclic heart canisters base their health attribute modifier off base health, which some mods can modify. This effectively negates the change they should have had.

Although those mods shouldn't be changing base health, for mod compatibility and future proofing it would be good to move away from basing calculations off base health. Also with the bonus of having `setMaxHealth` no longer being misleading as it is now `setMaxHealthModifier`

## PR Notes
As suggested in https://github.com/Lothrazar/Cyclic/pull/870 this PR changes Cyclic from using Max Health to using Max Health Modifier (Bonus health in https://github.com/Lothrazar/Cyclic/pull/870).

Code is put in place to migrate the config for the heart canisters and player data. Although I wasn't sure where was best to put migration code for the `setheartmod` (prior `sethearts`) command so the configs for that aren't migrated.

The text that pops up when you use a heart used to be "maxHealth" ignoring health modifiers from other mods. Now it's changed to be the health modifier instead. so basically -10 of the old values.

Unfortunately even with these changes MineKraft: Ultra still seems to be buggy with the health, especially when you when you die or update health.

Let me know if these changes are okay or if anything needs to change (like I'm not 100% sure about the naming I've used, or like that popup text changing).

[Video Demonstration of the PR](https://www.youtube.com/watch?v=_tepVM7WgEY)

## Related Issues
https://github.com/Lothrazar/Cyclic/pull/870 (Implements the second suggestion in this)
https://github.com/Lothrazar/Cyclic/issues/1258 (Issue showing incompatibility with mods that change base health)